### PR TITLE
Revert "chore(deps-dev): bump @types/express from 4.17.2 to 4.17.6"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -550,9 +550,9 @@
       "dev": true
     },
     "@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -627,13 +627,12 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
-        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
@@ -808,11 +807,6 @@
       "requires": {
         "@types/express": "*"
       }
-    },
-    "@types/qs": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw=="
     },
     "@types/range-parser": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/cross-spawn": "^6.0.1",
     "@types/dotenv": "^8.2.0",
     "@types/errorhandler": "1.5.0",
-    "@types/express": "^4.17.6",
+    "@types/express": "^4.17.2",
     "@types/graphql": "^14.5.0",
     "@types/jsonwebtoken": "^8.3.9",
     "@types/knex": "^0.16.1",


### PR DESCRIPTION
New version has weird typing issues, wait for the next one.

Reverts Klemensas/seenit-server#147